### PR TITLE
FEATURE: Allow users to configure a sorting option

### DIFF
--- a/Classes/Sitegeist/CriticalMass/Hooks/ContentRepositoryHooks.php
+++ b/Classes/Sitegeist/CriticalMass/Hooks/ContentRepositoryHooks.php
@@ -11,6 +11,8 @@ use TYPO3\Eel\CompilingEvaluator;
 
 use TYPO3\Eel\FlowQuery\FlowQuery as FlowQuery;
 
+use Sitegeist\CriticalMass\Service\NodeSortingService;
+
 /**
  * @Flow\Scope("singleton")
  */
@@ -40,6 +42,12 @@ class ContentRepositoryHooks
      * @Flow\InjectConfiguration("automaticNodeHierarchy")
      */
     protected $automaticNodeHierarchyConfigurations;
+
+    /**
+     * @Flow\Inject
+     * @var NodeSortingService
+     */
+    protected $nodeSortingService;
 
     /**
      * Signal that is triggered on node create
@@ -131,6 +139,13 @@ class ContentRepositoryHooks
                             $nextCollectionNode->setProperty($propertyName, $propertyValue);
                         }
                     }
+                }
+
+                if (array_key_exists('sortBy', $pathItemConfiguration) && $pathItemConfiguration['sortBy']) {
+                    $this->nodeSortingService->sortChildNodesByEelExpression(
+                        $targetCollectionNode,
+                        $pathItemConfiguration['sortBy']
+                    );
                 }
 
                 $targetCollectionNode = $nextCollectionNode;

--- a/Classes/Sitegeist/CriticalMass/Service/NodeSortingService.php
+++ b/Classes/Sitegeist/CriticalMass/Service/NodeSortingService.php
@@ -1,0 +1,70 @@
+<?php
+namespace Sitegeist\CriticalMass\Service;
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Eel\Utility as EelUtility;
+use TYPO3\Eel\CompilingEvaluator;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+class NodeSortingService
+{
+	/**
+     * @Flow\Inject(lazy=FALSE)
+     * @var CompilingEvaluator
+     */
+    protected $eelEvaluator;
+
+	/**
+     * @Flow\InjectConfiguration(path="defaultContext", package="TYPO3.TypoScript")
+     * @var array
+     */
+    protected $defaultTypoScriptContextConfiguration;
+
+	/**
+	 * @param NodeInterface $node
+	 * @param string $eelExpression
+	 * @param string $nodeTypeFilter
+	 * @return void
+	 */
+	public function sortChildNodesByEelExpression(
+		NodeInterface $node,
+		$eelExpression,
+		$nodeTypeFilter = 'TYPO3.Neos:Document'
+	) {
+		$nodes = $node->getChildNodes($nodeTypeFilter);
+
+		foreach ($nodes as $subject) {
+
+			$object = null;
+			foreach ($nodes as $node) {
+				if ($this->sortingConditionApplies($subject, $node)) {
+					$object = $node;
+					break;
+				}
+			}
+
+			if ($object) {
+				$subject->moveBefore($object);
+			}
+		}
+	}
+
+	/**
+	 * @param NodeInterface $a
+	 * @param NodeInterface $b
+	 * @param string $eelExpression
+	 * @return boolean
+	 */
+	protected function sortingConditionApplies(NodeInterface $a, NodeInterface $b, $eelExpression)
+	{
+		return EelUtility::evaluateEelExpression(
+			$eelExpression,
+			$this->eelEvaluator,
+			['a' => $a, 'b' => $b],
+			$this->defaultTypoScriptContextConfiguration
+		);
+	}
+}

--- a/Classes/Sitegeist/CriticalMass/Service/NodeSortingService.php
+++ b/Classes/Sitegeist/CriticalMass/Service/NodeSortingService.php
@@ -40,7 +40,7 @@ class NodeSortingService
 
 			$object = null;
 			foreach ($nodes as $node) {
-				if ($this->sortingConditionApplies($subject, $node)) {
+				if ($this->sortingConditionApplies($subject, $node, $eelExpression)) {
 					$object = $node;
 					break;
 				}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Sitegeist:
             type: 'Sitegeist.CriticalMass:ExampleNodeCollection'
             name: "${'node-event-year-' + (q(node).property('startDate') ? Date.year(q(node).property('startDate')) : 'no-year')}"
             
+            # optional: the sorting of the nodes on this level
+            sortBy: '${q(a).property("title") < q(b).property("title")}'
+             
             # properties that are applied only on node creation and can be edited afterwards
             properties:
               title: "${q(node).property('startDate') ? Date.year(q(node).property('startDate')) : 'no-year'}"
@@ -62,6 +65,9 @@ Sitegeist:
             type: 'Sitegeist.CriticalMass:ExampleNodeCollection'
             name: "${'node-event-month-' + (q(node).property('startDate') ? Date.month(q(node).property('startDate')) : 'no-month')}"
             
+            # optional: the sorting of the nodes on this level
+            sortBy: '${q(a).property("title") < q(b).property("title")}'
+             
             # properties that are applied only on node creation and can be edited afterwards
             properties:
               title: "${q(node).property('startDate') ? Date.month(q(node).property('startDate')) : 'no-month'}"


### PR DESCRIPTION
Sorting can be configured like this:

```yaml

Sitegeist:
  CriticalMass:
    automaticNodeHierarchy:
      'MyAwesome.Package:MyAwesome.NodeType':
        root: '' 
        path:
          -
            name: ''
            type: ''
            sortBy: '${q(a).property("title") < q(b).property("title")}'
            properties: {}
```

The `sortBy` key can be specified for each path segment. It is evaluated as an Eel expression with the TypoScript default context and two additional context variables `a` and `b`, which represent nodes. 

The Eel expression should return a `boolean` value. Whenever it evaluates to `true`, the node sorting service will know to move `a` before `b`.

Sorting is triggered whenever the automatic node hierarchy is built. So on every node creation  and/or update, sorting is applied to the respective parent nodes in the hierarchy.
