### PR TITLE
FEATURE: Add option to automatically publish the auto-created node hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Sitegeist:
         # Detect the root-collection node that will contain the automatically created node hierarchy
         root: "${q(node).parents().filter('[instanceof Sitegeist.CriticalMass:ExampleNodeCollection]').slice(-1, 1).get(0)}"
         
+        # optional: Automatically publish the created document hierarchy
+        autoPublishPath: true
+        
         # Define the levels of the node hierarchy that are created beneath the root node
         path:
        


### PR DESCRIPTION
To enable autmatic publishing, just set the following option:

```yaml
Sitegeist:
  CriticalMass:
    automaticNodeHierarchy:
      'MyAwesome.Package:MyAwesome.NodeType':
        root: ''
        autoPublishPath: true
```

With `autoPublishPath` set to `true`, all nodes that are created during the hierarchy generation, will automatically be published to the live workspace.

This is to get around the issue, that editors are unaware of the process behind `CriticalMass`, thus focusing on the node they just created. After publishing, they get an unexpected result, because the auto-created hierarchy didn't get published as well.

In most cases, the publishing status of those hierarchy nodes doesn't matter, but just to enable the case in which it does matter, this is solved by providing an option.